### PR TITLE
Add Vacuum.RemoveLayerLink function

### DIFF
--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -142,7 +142,7 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 			}
 			for _, layerDgst := range obj.Layers {
 				if _, ok := markSet[layerDgst]; !ok {
-					err := vacuum.RemoveLayerLink(obj.Name, string(layerDgst))
+					err := vacuum.RemoveLayerLink(obj.Name, layerDgst)
 					if err != nil {
 						return fmt.Errorf("failed to delete layer link %s for manifest %s: %v", layerDgst, obj.Name, err)
 					}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -25,6 +25,7 @@ type ManifestDel struct {
 	Name   string
 	Digest digest.Digest
 	Tags   []string
+	Layers []digest.Digest
 }
 
 // MarkAndSweep performs a mark and sweep of registry data
@@ -61,6 +62,11 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 		}
 
 		err = manifestEnumerator.Enumerate(ctx, func(dgst digest.Digest) error {
+			manifest, err := manifestService.Get(ctx, dgst)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve manifest for digest %v: %v", dgst, err)
+			}
+
 			if opts.RemoveUntagged {
 				// fetch all tags where this manifest is the latest one
 				tags, err := repository.Tags(ctx).Lookup(ctx, distribution.Descriptor{Digest: dgst})
@@ -76,18 +82,29 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 					if err != nil {
 						return fmt.Errorf("failed to retrieve tags %v", err)
 					}
-					manifestArr = append(manifestArr, ManifestDel{Name: repoName, Digest: dgst, Tags: allTags})
+
+					manifestDel := ManifestDel{
+						Name:   repoName,
+						Digest: dgst,
+						Tags:   allTags,
+						Layers: []digest.Digest{},
+					}
+
+					for _, ref := range manifest.References() {
+						if ref.MediaType == schema2.MediaTypeLayer ||
+							ref.MediaType == schema2.MediaTypeImageConfig {
+							manifestDel.Layers = append(manifestDel.Layers, ref.Digest)
+						}
+					}
+
+					manifestArr = append(manifestArr, manifestDel)
+
 					return nil
 				}
 			}
 			// Mark the manifest's blob
 			emit("%s: marking manifest %s ", repoName, dgst)
 			markSet[dgst] = struct{}{}
-
-			manifest, err := manifestService.Get(ctx, dgst)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve manifest for digest %v: %v", dgst, err)
-			}
 
 			descriptors := manifest.References()
 			for _, descriptor := range descriptors {
@@ -121,6 +138,14 @@ func MarkAndSweep(ctx context.Context, storageDriver driver.StorageDriver, regis
 			err = vacuum.RemoveManifest(obj.Name, obj.Digest, obj.Tags)
 			if err != nil {
 				return fmt.Errorf("failed to delete manifest %s: %v", obj.Digest, err)
+			}
+			for _, layerDgst := range obj.Layers {
+				if _, ok := markSet[layerDgst]; !ok {
+					err := vacuum.RemoveLayerLink(obj.Name, string(layerDgst))
+					if err != nil {
+						return fmt.Errorf("failed to delete layer link %s for manifest %s: %v", layerDgst, obj.Name, err)
+					}
+				}
 			}
 		}
 	}

--- a/registry/storage/garbagecollect.go
+++ b/registry/storage/garbagecollect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/storage/driver"
 	"github.com/opencontainers/go-digest"

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -103,12 +103,7 @@ func (v Vacuum) RemoveLayerLink(manifestName string, dgst digest.Digest) error {
 		}
 	}
 
-	err = v.driver.Delete(v.ctx, layerLinkPath)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return v.driver.Delete(v.ctx, layerLinkPath)
 }
 
 // RemoveRepository removes a repository directory from the

--- a/registry/storage/vacuum.go
+++ b/registry/storage/vacuum.go
@@ -85,13 +85,8 @@ func (v Vacuum) RemoveManifest(name string, dgst digest.Digest, tags []string) e
 }
 
 // RemoveLayerLink removes a layer link from the filesystem
-func (v Vacuum) RemoveLayerLink(manifestName, dgst string) error {
-	d, err := digest.Parse(dgst)
-	if err != nil {
-		return err
-	}
-
-	layerLinkPath, err := pathFor(layerLinkPathSpec{name: manifestName, digest: d})
+func (v Vacuum) RemoveLayerLink(manifestName string, dgst digest.Digest) error {
+	layerLinkPath, err := pathFor(layerLinkPathSpec{name: manifestName, digest: dgst})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently MarkAndSweep garbage collection only deletes manifests, manifest tag references, and blobs.

It leaves behind orphaned "link" files that look like `<root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link`; these are repository-specific links to items in the blob store that we no longer need once the blob has been deleted.