### PR TITLE
manifests: Return UNSUPPORTED when deleting manifests by tag

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -15,11 +15,11 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/distribution/registry/api/v2"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // These constants determine which architecture and OS to choose from a
@@ -484,6 +484,11 @@ func (imh *manifestHandler) applyResourcePolicy(manifest distribution.Manifest) 
 // DeleteManifest removes the manifest with the given digest from the registry.
 func (imh *manifestHandler) DeleteManifest(w http.ResponseWriter, r *http.Request) {
 	dcontext.GetLogger(imh).Debug("DeleteImageManifest")
+
+	if imh.Tag != "" {
+		imh.Errors = append(imh.Errors, errcode.ErrorCodeUnsupported)
+		return
+	}
 
 	manifests, err := imh.Repository.Manifests(imh)
 	if err != nil {


### PR DESCRIPTION
The OCI distribution spec allows implementations to support deleting manifests by tag, but also permits returning the `UNSUPPORTED` error code for such requests. docker/distribution has never supported deleting manifests by tag, but previously returned `DIGEST_INVALID`.

The `Tag` and `Digest` fields of the `manifestHandler` are already correctly populated based on which kind of reference was given in the request URL. Return `UNSUPPORTED` if the `Tag` field is populated.

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>