### PR TITLE
OCI: GET request to deleted blob URL should yield 404 response

### DIFF
--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -47,7 +47,7 @@ type linkedBlobStore struct {
 var _ distribution.BlobStore = &linkedBlobStore{}
 
 func (lbs *linkedBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	return lbs.blobStore.statter.Stat(ctx, dgst)
+	return lbs.blobAccessController.Stat(ctx, dgst)
 }
 
 func (lbs *linkedBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {


### PR DESCRIPTION
This addresses the [`GET request to deleted blob URL should yield 404 response`](https://github.com/opencontainers/distribution-spec/blob/a6e5b091b1468662730ab1e5be55c61838643ab4/conformance/04_management_test.go#L159-L166) failure that we've seen when running the OCI compliance suite against DOCR.

The problem seems to boil down to the `linkedBlobStore` using a statter that stats the actual blob rather that the blob link whereas in the `docker/distribution` model of blob deletion we can only ever delete layer links (references to the actual blobs) unless we set the registry to RO mode to run GC process, at which time unreferenced blobs (blobs that are completely unreferenced by any manifests) can actually be deleted.

So because the blob itself is, by the design of docker/distribution, the wrong thing to stat this PR changes the implementation of the `linkedBlobStore.Stat` method to use `lbs.blobAccessController.Stat` rather than `lbs.blobStore.statter.Stat`.

The ultimate difference can be seen in the logs created during the `GetBlob` call resulting from [`GET request to deleted blob URL should yield 404 response`](https://github.com/opencontainers/distribution-spec/blob/a6e5b091b1468662730ab1e5be55c61838643ab4/conformance/04_management_test.go#L159-L166) before this PR:

```
Jul 28 21:26:46 |DEBU| GetBlob
Jul 28 21:26:47 |DEBU| s3aws.Stat("/docker/registry/v2/blobs/sha256/66/66ad98165d38f53ee73868f82bd4eed60556ddfee824810a4062c4f777b20a5b/data") trace.line=155 trace.duration=141044916 trace.id="07e7e76c-dfc8-4378-830b-f15365a4456b" trace.func="github.com/docker/distribution/registry/storage/driver/base.(*Base).Stat" trace.file="/home/wayne/projects/gopath/pkg/mod/github.com/digitalocean/docker-distribution@v0.0.0-20200602224622-f8c65fc7c52e/registry/storage/driver/base/base.go"
Jul 28 21:26:47 |DEBU| s3aws.URLFor("/docker/registry/v2/blobs/sha256/66/66ad98165d38f53ee73868f82bd4eed60556ddfee824810a4062c4f777b20a5b/data") trace.line=217 trace.duration=412763 trace.id="431aa019-7a60-4359-9439-0b70cc3bd505" trace.func="github.com/docker/distribution/registry/storage/driver/base.(*Base).URLFor"
Jul 28 21:26:47 |INFO| response completed http.response.written=0 http.response.status=307 http.response.duration="281.062124ms" http.response.contenttype="application/octet-stream"
```

and after:
```
Jul 29 22:32:48 |DEBU| GetBlob
Jul 29 22:32:48 |DEBU| s3aws.GetContent("/docker/registry/v2/repositories/myrepo/_layers/sha256/66ad98165d38f53ee73868f82bd4eed60556ddfee824810a4062c4f777b20a5b/link") trace.line=95 trace.duration=203391309 trace.id="766ab92e-0b84-4a8f-8380-bd7b4c5847e5" trace.file="/home/wayne/projects/distribution/registry/storage/driver/base/base.go" trace.func="github.com/docker/distribution/registry/storage/driver/base.(*Base).GetContent"
Jul 29 22:32:48 |ERRO| response completed with error err.code="blob unknown" http.response.status=404 http.response.written=157 http.response.duration="401.151664ms" err.message="blob unknown to registry" http.response.contenttype="application/json" err.detail="sha256:66ad98165d38f53ee73868f82bd4eed60556ddfee824810a4062c4f777b20a5b"
```

The difference between `lbs.blobAccessController` and `lbs.blobStore` can be seen [in the github.com/docker/distribution/registry/storage.repository.Blobs() method](https://github.com/docker/distribution/blob/208d68bd5cc980d370eae6ba3e021b630a46a7e7/registry/storage/registry.go#L304-L337); `lbs.blobStore` uses the `repository.blobStore` which is actually [the registry's blobstore](https://github.com/docker/distribution/blob/208d68bd5cc980d370eae6ba3e021b630a46a7e7/registry/storage/registry.go#L194) which explains why it yields the actual blob path rather than the repository's layer link path.