### PR TITLE
Revert "OCI: GET request to deleted blob URL should yield 404 response"

### DIFF
--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -47,7 +47,7 @@ type linkedBlobStore struct {
 var _ distribution.BlobStore = &linkedBlobStore{}
 
 func (lbs *linkedBlobStore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	return lbs.blobAccessController.Stat(ctx, dgst)
+	return lbs.blobStore.statter.Stat(ctx, dgst)
 }
 
 func (lbs *linkedBlobStore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {


### PR DESCRIPTION
Using the linked blob store for blob requests fixes a conformance issue and works correctly for newly-pushed images. However, any images that were pushed before the change could be missing layer links (since previously it was possible to fetch a blob without the layer link existing) and it's not possible to pull these iamges after the change.

Revert the change to use the linked blob store, for now, until we can figure out how to fix this without breaking existing repositories.

This reverts commit 71f1c25220ebed23471cd5d586223edb5deb7060 / PR #5 