### PR TITLE
s3: don't use s3.ListObjectsV2Output.KeyCount

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1105,15 +1105,17 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 
 		var count int64
 		// KeyCount was introduced with version 2 of the GET Bucket operation in S3.
-		// Some S3 implementations don't support V2 now, so we fall back to manual
-		// calculation of the key count if required
-		if objects.KeyCount != nil {
-			count = *objects.KeyCount
-			*objectCount += *objects.KeyCount
-		} else {
-			count = int64(len(objects.Contents) + len(objects.CommonPrefixes))
-			*objectCount += count
-		}
+		// Some s3 implementations (looking at you ceph/rgw) have a buggy
+		// implementation so we intionally avoid ever using it, preferring instead
+		// to calculate the count from the Contents and CommonPrefixes fields of
+		// the s3.ListObjectsV2Output. we retain the commented out KeyCount code
+		// and this comment so as not to forget this problem moving forward.
+		//
+		// count = *objects.KeyCount
+		// *objectCount += *objects.KeyCount
+
+		count = int64(len(objects.Contents) + len(objects.CommonPrefixes))
+		*objectCount += count
 
 		walkInfos := make([]walkInfoContainer, 0, count)
 


### PR DESCRIPTION
This change appears to work around one of the sources of flakiness I've been encountering in some DOCR backend e2e tests when the DOCR garbage collector is built with it in place. It also seems like a reasonable change to make given that the new behavior is the same as the previous for S3 implementations that don't include `KeyCount` at all.

We don't yet have a link to a public/upstream Ceph radosgateway bug report to link here but in the Spaces teams' internal ticketing system the problem is roughly described as:

```
Bugs in ListObjects(v2)
- keycount not including common prefix count
- common prefixes not displaying correct prefixes
- contents not being displayed alongside common prefixes
- applies to both normal and versioned buckets
```