### PR TITLE
Handle S3 QuotaExceeded errors appropriately

### DIFF
--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/auth"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/gorilla/handlers"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -369,6 +370,8 @@ func (imh *manifestHandler) PutManifest(w http.ResponseWriter, r *http.Request) 
 					}
 				}
 			}
+		case storagedriver.QuotaExceededError:
+			imh.Errors = append(imh.Errors, errcode.ErrorCodeDenied.WithMessage("quota exceeded"))
 		case errcode.Error:
 			imh.Errors = append(imh.Errors, err)
 		default:

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -80,6 +80,9 @@ func (base *Base) setDriverName(e error) error {
 	case storagedriver.InvalidOffsetError:
 		actual.DriverName = base.StorageDriver.Name()
 		return actual
+	case storagedriver.QuotaExceededError:
+		actual.DriverName = base.StorageDriver.Name()
+		return actual
 	default:
 		storageError := storagedriver.Error{
 			DriverName: base.StorageDriver.Name(),

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1300,7 +1300,7 @@ func (w *writer) Write(p []byte) (int, error) {
 				Key:      aws.String(w.key),
 				UploadId: aws.String(w.uploadID),
 			})
-			return 0, err
+			return 0, parseError(w.key, err)
 		}
 
 		resp, err := w.driver.S3.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
@@ -1312,7 +1312,7 @@ func (w *writer) Write(p []byte) (int, error) {
 			StorageClass:         w.driver.getStorageClass(),
 		})
 		if err != nil {
-			return 0, err
+			return 0, parseError(w.key, err)
 		}
 		w.uploadID = *resp.UploadId
 
@@ -1324,7 +1324,7 @@ func (w *writer) Write(p []byte) (int, error) {
 				Key:    aws.String(w.key),
 			})
 			if err != nil {
-				return 0, err
+				return 0, parseError(w.key, err)
 			}
 			defer resp.Body.Close()
 			w.parts = nil
@@ -1342,7 +1342,7 @@ func (w *writer) Write(p []byte) (int, error) {
 				UploadId:   resp.UploadId,
 			})
 			if err != nil {
-				return 0, err
+				return 0, parseError(w.key, err)
 			}
 			w.parts = []*s3.Part{
 				{
@@ -1415,7 +1415,7 @@ func (w *writer) Cancel() error {
 		Key:      aws.String(w.key),
 		UploadId: aws.String(w.uploadID),
 	})
-	return err
+	return parseError(w.key, err)
 }
 
 func (w *writer) Commit() error {
@@ -1456,7 +1456,7 @@ func (w *writer) Commit() error {
 			Key:      aws.String(w.key),
 			UploadId: aws.String(w.uploadID),
 		})
-		return err
+		return parseError(w.key, err)
 	}
 	return nil
 }
@@ -1484,7 +1484,7 @@ func (w *writer) flushPart() error {
 		Body:       bytes.NewReader(w.readyPart),
 	})
 	if err != nil {
-		return err
+		return parseError(w.key, err)
 	}
 	w.parts = append(w.parts, &s3.Part{
 		ETag:       resp.ETag,

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1188,8 +1188,13 @@ func (d *Driver) S3BucketKey(path string) string {
 }
 
 func parseError(path string, err error) error {
-	if s3Err, ok := err.(awserr.Error); ok && s3Err.Code() == "NoSuchKey" {
-		return storagedriver.PathNotFoundError{Path: path}
+	if s3Err, ok := err.(awserr.Error); ok {
+		switch s3Err.Code() {
+		case "NoSuchKey":
+			return storagedriver.PathNotFoundError{Path: path}
+		case "QuotaExceeded":
+			return storagedriver.QuotaExceededError{}
+		}
 	}
 
 	return err

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -159,6 +159,16 @@ func (err InvalidOffsetError) Error() string {
 	return fmt.Sprintf("%s: invalid offset: %d for path: %s", err.DriverName, err.Offset, err.Path)
 }
 
+// QuotaExceededError is returned when a storage quota is exceeded during a
+// write.
+type QuotaExceededError struct {
+	DriverName string
+}
+
+func (err QuotaExceededError) Error() string {
+	return fmt.Sprintf("%s: quota exceeded", err.DriverName)
+}
+
 // Error is a catch-all error type which captures an error string and
 // the driver type on which it occurred.
 type Error struct {


### PR DESCRIPTION
This PR contains three changes necessary to pass along `QuotaExceeded` errors from S3 to the client in a reasonable way:

1. Parse S3 errors received during multipart uploads. Previously these errors were passed back to the caller as-is, which meant errors we understand like `NoSuchKey` wouldn't be parsed properly.
2. Parse the S3 `QuotaExceeded` error into a new `storagedriver` error created for this purpose. This will let consumers of the storage drivers handle quota errors as they see fit.
3. Handle quota errors received from the storage driver in the manifest and blob handlers. Translate them into `DENIED` errors with the message `quota exceeded`, so that the client gets some indication of what's gone wrong and won't blindly retry.