### PR TITLE
s3: work around buggy s3 api client implementation

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -733,7 +733,7 @@ func (d *driver) Stat(ctx context.Context, path string) (storagedriver.FileInfo,
 		Bucket: aws.String(d.Bucket),
 		Key:    aws.String(d.s3Path(path)),
 	})
-	if err == nil {
+	if err == nil && headResp.ContentLength != nil {
 		if headResp.ContentLength != nil {
 			fi.Size = *headResp.ContentLength
 		}

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -599,6 +599,10 @@ var setContentLength = request.NamedHandler{
 			if r.HTTPResponse.ContentLength > 0 {
 				v.SetContentLength(r.HTTPResponse.ContentLength)
 			}
+		case *s3.GetObjectOutput:
+			if r.HTTPResponse.ContentLength > 0 {
+				v.SetContentLength(r.HTTPResponse.ContentLength)
+			}
 		}
 	},
 }

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -585,6 +585,24 @@ func (d *driver) logS3Operation(ctx context.Context) request.NamedHandler {
 	}
 }
 
+// setContentLengthHandlerHame is used to identify the handler used set the
+// ContentLength field on request data output types that support it.
+const setContentLengthHandlerName = "docker.storage-driver.s3.set-content-length"
+
+// setContentLength is used to set the ContentLength field on request data
+// output types that support it.
+var setContentLength = request.NamedHandler{
+	Name: setContentLengthHandlerName,
+	Fn: func(r *request.Request) {
+		switch v := r.Data.(type) {
+		case *s3.HeadObjectOutput:
+			if r.HTTPResponse.ContentLength > 0 {
+				v.SetContentLength(r.HTTPResponse.ContentLength)
+			}
+		}
+	},
+}
+
 func (d *driver) s3Client(ctx context.Context) *s3.S3 {
 	s := d.S3
 
@@ -593,6 +611,7 @@ func (d *driver) s3Client(ctx context.Context) *s3.S3 {
 		r := d.logS3Operation(ctx)
 		s.Client.Handlers.Complete.PushBackNamed(r)
 	}
+	s.Client.Handlers.Complete.PushBackNamed(setContentLength)
 
 	return s
 }


### PR DESCRIPTION
* use a request handler to set ContentLength on HeadObjectOutput
* ignore HeadObjectOutput if it doesn't have ContentLength. doesn't
  actually fix the bug for DO's Spaces but we should try the fallback
  anyway