### PR TITLE
registry/cshoop/storagedriver Added StorageDriver method WalkFiles, optimize blobstore enumeration with S3

### DIFF
--- a/registry/storage/blobstore.go
+++ b/registry/storage/blobstore.go
@@ -93,12 +93,7 @@ func (bs *blobStore) Enumerate(ctx context.Context, ingester func(dgst digest.Di
 		return err
 	}
 
-	return bs.driver.Walk(ctx, specPath, func(fileInfo driver.FileInfo) error {
-		// skip directories
-		if fileInfo.IsDir() {
-			return nil
-		}
-
+	return bs.driver.WalkFiles(ctx, specPath, func(fileInfo driver.FileInfo) error {
 		currentPath := fileInfo.Path()
 		// we only want to parse paths that end with /data
 		_, fileName := path.Split(currentPath)

--- a/registry/storage/driver/azure/azure.go
+++ b/registry/storage/driver/azure/azure.go
@@ -360,9 +360,15 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 }
 
 // Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
+// from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
 	return storagedriver.WalkFallback(ctx, d, path, f)
+}
+
+// WalkFiles traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file
+func (d *driver) WalkFiles(ctx context.Context, path string, f storagedriver.WalkFn) error {
+	return storagedriver.WalkFilesFallback(ctx, d, path, f)
 }
 
 // directDescendants will find direct descendants (blobs or virtual containers)

--- a/registry/storage/driver/base/base.go
+++ b/registry/storage/driver/base/base.go
@@ -241,3 +241,15 @@ func (base *Base) Walk(ctx context.Context, path string, f storagedriver.WalkFn)
 
 	return base.setDriverName(base.StorageDriver.Walk(ctx, path, f))
 }
+
+// WalkFiles wraps WalkFiles of underlying storage driver.
+func (base *Base) WalkFiles(ctx context.Context, path string, f storagedriver.WalkFn) error {
+	ctx, done := dcontext.WithTrace(ctx)
+	defer done("%s.WalkFiles(%q)", base.Name(), path)
+
+	if !storagedriver.PathRegexp.MatchString(path) && path != "/" {
+		return storagedriver.InvalidPathError{Path: path, DriverName: base.StorageDriver.Name()}
+	}
+
+	return base.setDriverName(base.StorageDriver.WalkFiles(ctx, path, f))
+}

--- a/registry/storage/driver/filesystem/driver.go
+++ b/registry/storage/driver/filesystem/driver.go
@@ -290,9 +290,15 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 }
 
 // Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
+// from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
 	return storagedriver.WalkFallback(ctx, d, path, f)
+}
+
+// WalkFiles traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file
+func (d *driver) WalkFiles(ctx context.Context, path string, f storagedriver.WalkFn) error {
+	return storagedriver.WalkFilesFallback(ctx, d, path, f)
 }
 
 // fullPath returns the absolute path of a key within the Driver's storage.

--- a/registry/storage/driver/inmemory/driver.go
+++ b/registry/storage/driver/inmemory/driver.go
@@ -245,9 +245,15 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 }
 
 // Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
+// from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
 	return storagedriver.WalkFallback(ctx, d, path, f)
+}
+
+// WalkFiles traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file
+func (d *driver) WalkFiles(ctx context.Context, path string, f storagedriver.WalkFn) error {
+	return storagedriver.WalkFilesFallback(ctx, d, path, f)
 }
 
 type writer struct {

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1210,12 +1210,10 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 				return false
 			}
 
-			if walkDirectories {
-				if walkInfo.IsDir() {
-					if err := d.doWalk(ctx, objectCount, *walkInfo.prefix, prefix, walkDirectories, f); err != nil {
-						retError = err
-						return false
-					}
+			if walkInfo.IsDir() && walkDirectories {
+				if err := d.doWalk(ctx, objectCount, *walkInfo.prefix, prefix, walkDirectories, f); err != nil {
+					retError = err
+					return false
 				}
 			}
 		}

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1057,7 +1057,7 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 }
 
 // Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
+// from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn) error {
 	path := from
 	if !strings.HasSuffix(path, "/") {
@@ -1070,7 +1070,33 @@ func (d *driver) Walk(ctx context.Context, from string, f storagedriver.WalkFn) 
 	}
 
 	var objectCount int64
-	if err := d.doWalk(ctx, &objectCount, d.s3Path(path), prefix, f); err != nil {
+	if err := d.doWalk(ctx, &objectCount, d.s3Path(path), prefix, true, f); err != nil {
+		return err
+	}
+
+	// S3 doesn't have the concept of empty directories, so it'll return path not found if there are no objects
+	if objectCount == 0 {
+		return storagedriver.PathNotFoundError{Path: from}
+	}
+
+	return nil
+}
+
+// WalkFiles traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file
+func (d *driver) WalkFiles(ctx context.Context, from string, f storagedriver.WalkFn) error {
+	path := from
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+
+	prefix := ""
+	if d.s3Path("") == "" {
+		prefix = "/"
+	}
+
+	var objectCount int64
+	if err := d.doWalk(ctx, &objectCount, d.s3Path(path), prefix, false, f); err != nil {
 		return err
 	}
 
@@ -1110,13 +1136,17 @@ func (wi walkInfoContainer) IsDir() bool {
 	return wi.FileInfoFields.IsDir
 }
 
-func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, prefix string, f storagedriver.WalkFn) error {
+func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, prefix string, walkDirectories bool, f storagedriver.WalkFn) error {
 	var retError error
 
+	delimiter := ""
+	if walkDirectories {
+		delimiter = "/"
+	}
 	listObjectsInput := &s3.ListObjectsV2Input{
 		Bucket:    aws.String(d.Bucket),
 		Prefix:    aws.String(path),
-		Delimiter: aws.String("/"),
+		Delimiter: aws.String(delimiter),
 		MaxKeys:   aws.Int64(listMax),
 	}
 
@@ -1180,10 +1210,12 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 				return false
 			}
 
-			if walkInfo.IsDir() {
-				if err := d.doWalk(ctx, objectCount, *walkInfo.prefix, prefix, f); err != nil {
-					retError = err
-					return false
+			if walkDirectories {
+				if walkInfo.IsDir() {
+					if err := d.doWalk(ctx, objectCount, *walkInfo.prefix, prefix, walkDirectories, f); err != nil {
+						retError = err
+						return false
+					}
 				}
 			}
 		}

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -90,6 +90,11 @@ type StorageDriver interface {
 	// to a directory, the directory will not be entered and Walk
 	// will continue the traversal.  If fileInfo refers to a normal file, processing stops
 	Walk(ctx context.Context, path string, f WalkFn) error
+
+	// WalkFiles traverses a filesystem defined within driver, starting
+	// from the given path, calling f on each file but does not call f with directories.
+	// If an error is returned from the WalkFn, processing stops
+	WalkFiles(ctx context.Context, path string, f WalkFn) error
 }
 
 // FileWriter provides an abstraction for an opened writable file-like object in

--- a/registry/storage/driver/swift/swift.go
+++ b/registry/storage/driver/swift/swift.go
@@ -658,9 +658,15 @@ func (d *driver) URLFor(ctx context.Context, path string, options map[string]int
 }
 
 // Walk traverses a filesystem defined within driver, starting
-// from the given path, calling f on each file
+// from the given path, calling f on each file and directory
 func (d *driver) Walk(ctx context.Context, path string, f storagedriver.WalkFn) error {
 	return storagedriver.WalkFallback(ctx, d, path, f)
+}
+
+// WalkFiles traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file
+func (d *driver) WalkFiles(ctx context.Context, path string, f storagedriver.WalkFn) error {
+	return storagedriver.WalkFilesFallback(ctx, d, path, f)
 }
 
 func (d *driver) swiftPath(path string) string {

--- a/registry/storage/driver/walk.go
+++ b/registry/storage/driver/walk.go
@@ -22,48 +22,20 @@ type WalkFn func(fileInfo FileInfo) error
 // to a directory, the directory will not be entered and Walk
 // will continue the traversal.  If fileInfo refers to a normal file, processing stops
 func WalkFallback(ctx context.Context, driver StorageDriver, from string, f WalkFn) error {
-	children, err := driver.List(ctx, from)
-	if err != nil {
-		return err
-	}
-	sort.Stable(sort.StringSlice(children))
-	for _, child := range children {
-		// TODO(stevvooe): Calling driver.Stat for every entry is quite
-		// expensive when running against backends with a slow Stat
-		// implementation, such as s3. This is very likely a serious
-		// performance bottleneck.
-		fileInfo, err := driver.Stat(ctx, child)
-		if err != nil {
-			switch err.(type) {
-			case PathNotFoundError:
-				// repository was removed in between listing and enumeration. Ignore it.
-				logrus.WithField("path", child).Infof("ignoring deleted path")
-				continue
-			default:
-				return err
-			}
-		}
-		err = f(fileInfo)
-		if err == nil && fileInfo.IsDir() {
-			if err := WalkFallback(ctx, driver, child, f); err != nil {
-				return err
-			}
-		} else if err == ErrSkipDir {
-			// Stop iteration if it's a file, otherwise noop if it's a directory
-			if !fileInfo.IsDir() {
-				return nil
-			}
-		} else if err != nil {
-			return err
-		}
-	}
-	return nil
+	return doWalk(ctx, driver, from, true, f)
 }
 
 // WalkFilesFallback traverses a filesystem defined within driver, starting
 // from the given path, calling f on each file. It uses the List method and Stat to drive itself.
 // If an error is returned from WalkFn, processing stops
 func WalkFilesFallback(ctx context.Context, driver StorageDriver, from string, f WalkFn) error {
+	return doWalk(ctx, driver, from, false, f)
+}
+
+// WalkFilesFallback traverses a filesystem defined within driver, starting
+// from the given path, calling f on each file. It uses the List method and Stat to drive itself.
+// If an error is returned from WalkFn, processing stops
+func doWalk(ctx context.Context, driver StorageDriver, from string, walkDir bool, f WalkFn) error {
 	children, err := driver.List(ctx, from)
 	if err != nil {
 		return err
@@ -85,13 +57,20 @@ func WalkFilesFallback(ctx context.Context, driver StorageDriver, from string, f
 				return err
 			}
 		}
-		if !fileInfo.IsDir() {
+		err = nil
+		if !fileInfo.IsDir() || walkDir {
 			err = f(fileInfo)
-			if err != nil {
+		}
+		if err == nil && fileInfo.IsDir() {
+			if err := doWalk(ctx, driver, child, walkDir, f); err != nil {
 				return err
 			}
-		}
-		if err := WalkFallback(ctx, driver, child, f); err != nil {
+		} else if err == ErrSkipDir && walkDir {
+			// Stop iteration if it's a file, otherwise noop if it's a directory
+			if !fileInfo.IsDir() {
+				return nil
+			}
+		} else if err != nil {
 			return err
 		}
 	}

--- a/registry/storage/driver/walk_test.go
+++ b/registry/storage/driver/walk_test.go
@@ -45,3 +45,23 @@ func TestWalkFileRemoved(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 }
+
+func TestWalkFilesFileRemoved(t *testing.T) {
+	d := &changingFileSystem{
+		fileset: []string{"zoidberg", "bender"},
+		keptFiles: map[string]bool{
+			"zoidberg": true,
+		},
+	}
+	infos := []FileInfo{}
+	err := WalkFilesFallback(context.Background(), d, "", func(fileInfo FileInfo) error {
+		infos = append(infos, fileInfo)
+		return nil
+	})
+	if len(infos) != 1 || infos[0].Path() != "zoidberg" {
+		t.Errorf(fmt.Sprintf("unexpected path set during walk: %s", infos))
+	}
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+}

--- a/registry/storage/driver/walk_test.go
+++ b/registry/storage/driver/walk_test.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +27,31 @@ func (cfs *changingFileSystem) Stat(ctx context.Context, path string) (FileInfo,
 	}
 	return nil, PathNotFoundError{}
 }
+
+type fileSystem struct {
+	StorageDriver
+	fileset map[string][]string
+}
+
+func (cfs *fileSystem) List(_ context.Context, path string) ([]string, error) {
+	return cfs.fileset[path], nil
+}
+
+func (cfs *fileSystem) Stat(_ context.Context, path string) (FileInfo, error) {
+	_, isDir := cfs.fileset[path]
+	return &FileInfoInternal{
+		FileInfoFields: FileInfoFields{
+			Path:  path,
+			IsDir: isDir,
+			Size:  int64(len(path)),
+		},
+	}, nil
+}
+func (cfs *fileSystem) isDir(path string) bool {
+	_, isDir := cfs.fileset[path]
+	return isDir
+}
+
 func TestWalkFileRemoved(t *testing.T) {
 	d := &changingFileSystem{
 		fileset: []string{"zoidberg", "bender"},
@@ -63,5 +89,172 @@ func TestWalkFilesFileRemoved(t *testing.T) {
 	}
 	if err != nil {
 		t.Fatalf(err.Error())
+	}
+}
+
+func TestWalkFallback(t *testing.T) {
+	d := &fileSystem{
+		fileset: map[string][]string{
+			"/":    {"/a", "/b", "/c"},
+			"/a":   {"/a/1"},
+			"/b":   {"/b/1", "/b/2"},
+			"/c":   {"/c/1", "/c/2"},
+			"/a/1": {"/a/1/a", "/a/1/b"},
+		},
+	}
+	var expected int
+	for _, list := range d.fileset {
+		expected += len(list)
+	}
+
+	var walked []FileInfo
+	err := WalkFallback(context.Background(), d, "/", func(fileInfo FileInfo) error {
+		if fileInfo.IsDir() != d.isDir(fileInfo.Path()) {
+			t.Fatalf("fileInfo isDir not matching file system: expected %t actual %t", d.isDir(fileInfo.Path()), fileInfo.IsDir())
+		}
+		walked = append(walked, fileInfo)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if expected != len(walked) {
+		t.Fatalf("mismatch number of fileInfo walked, expected %d", expected)
+	}
+}
+
+// Walk is expected to skip directory on ErrSkipDir
+func TestWalkFallbackSkipDirOnDir(t *testing.T) {
+	d := &fileSystem{
+		fileset: map[string][]string{
+			"/":        {"/file1", "/folder1", "/folder2"},
+			"/folder1": {"/folder1/file1"}, // should not be walked
+			"/folder2": {"/folder2/file1"},
+		},
+	}
+	skipDir := "/folder1"
+	expected := []string{
+		"/file1",
+		"/folder1", // return ErrSkipDir, skip anything under /folder1
+		// skip /folder1/file1
+		"/folder2",
+		"/folder2/file1",
+	}
+
+	var walked []string
+	err := WalkFallback(context.Background(), d, "/", func(fileInfo FileInfo) error {
+		walked = append(walked, fileInfo.Path())
+		if fileInfo.Path() == skipDir {
+			return ErrSkipDir
+		}
+		if strings.Contains(fileInfo.Path(), skipDir) {
+			t.Fatalf("skipped dir %s and should not walk %s", skipDir, fileInfo.Path())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected Walk to not error %v", err)
+	}
+	compareWalked(t, expected, walked)
+}
+
+func TestWalkFallbackSkipDirOnFile(t *testing.T) {
+	d := &fileSystem{
+		fileset: map[string][]string{
+			"/": {"/file1", "/file2", "/file3"},
+		},
+	}
+	skipFile := "/file2"
+	expected := []string{
+		"/file1",
+		"/file2", // return ErrSkipDir, stop early
+	}
+
+	var walked []string
+	err := WalkFallback(context.Background(), d, "/", func(fileInfo FileInfo) error {
+		walked = append(walked, fileInfo.Path())
+		if fileInfo.Path() == skipFile {
+			return ErrSkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected Walk to not error %v", err)
+	}
+	compareWalked(t, expected, walked)
+}
+
+// WalkFiles is expected to only walk files, not directories
+func TestWalkFilesFallback(t *testing.T) {
+	d := &fileSystem{
+		fileset: map[string][]string{
+			"/":                {"/folder1", "/file1", "/folder2"},
+			"/folder1":         {"/folder1/folder1"},
+			"/folder2":         {"/folder2/file1", "/folder2/file2"},
+			"/folder1/folder1": {"/folder1/folder1/file1", "/folder1/folder1/file2"},
+		},
+	}
+	expected := []string{
+		"/file1",
+		"/folder1/folder1/file1",
+		"/folder1/folder1/file2",
+		"/folder2/file1",
+		"/folder2/file2",
+	}
+
+	var walked []string
+	err := WalkFilesFallback(context.Background(), d, "/", func(fileInfo FileInfo) error {
+		if fileInfo.IsDir() {
+			t.Fatalf("can't walk over dir %s", fileInfo.Path())
+		}
+		if fileInfo.IsDir() != d.isDir(fileInfo.Path()) {
+			t.Fatalf("fileInfo isDir not matching file system: expected %t actual %t", d.isDir(fileInfo.Path()), fileInfo.IsDir())
+		}
+		walked = append(walked, fileInfo.Path())
+		return nil
+	})
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	compareWalked(t, expected, walked)
+}
+
+// WalkFiles is expected to stop when any error is given
+func TestWalkFilesFallbackSkipDir(t *testing.T) {
+	d := &fileSystem{
+		fileset: map[string][]string{
+			"/":        {"/file1", "/folder1", "/folder2"},
+			"/folder1": {"/folder1/file1"},
+			"/folder2": {"/folder2/file1"},
+		},
+	}
+	skipFile := "/folder1/file1"
+	expected := []string{
+		"/file1", "/folder1/file1",
+	}
+
+	var walked []string
+	err := WalkFilesFallback(context.Background(), d, "/", func(fileInfo FileInfo) error {
+		fmt.Println("Walk ", fileInfo.Path())
+		walked = append(walked, fileInfo.Path())
+		if fileInfo.Path() == skipFile {
+			return ErrSkipDir
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected Walk to ErrSkipDir %v", err)
+	}
+	compareWalked(t, expected, walked)
+}
+
+func compareWalked(t *testing.T, expected, walked []string) {
+	if len(walked) != len(expected) {
+		t.Fatalf("Mismatch number of fileInfo walked %d expected %d", len(walked), len(expected))
+	}
+	for i := range walked {
+		if walked[i] != expected[i] {
+			t.Fatalf("expected walked to come in order expected: walked %s", walked)
+		}
 	}
 }

--- a/registry/storage/driver/walk_test.go
+++ b/registry/storage/driver/walk_test.go
@@ -103,7 +103,7 @@ func TestWalkFallback(t *testing.T) {
 	}
 	expected := []string{
 		"/file1",
-		"/folder1", // return ErrSkipDir, skip anything under /folder1
+		"/folder1",
 		"/folder1/file1",
 		"/folder2",
 		"/folder2/file1",

--- a/registry/storage/linkedblobstore.go
+++ b/registry/storage/linkedblobstore.go
@@ -247,11 +247,7 @@ func (lbs *linkedBlobStore) Enumerate(ctx context.Context, ingestor func(digest.
 	if err != nil {
 		return err
 	}
-	return lbs.driver.Walk(ctx, rootPath, func(fileInfo driver.FileInfo) error {
-		// exit early if directory...
-		if fileInfo.IsDir() {
-			return nil
-		}
+	return lbs.driver.WalkFiles(ctx, rootPath, func(fileInfo driver.FileInfo) error {
 		filePath := fileInfo.Path()
 
 		// check if it's a link


### PR DESCRIPTION
### **Objective**
blobstore enumeration with S3 storage driver (and possibly others with follow up effort) can be optimized by several orders of magnitude by offloading more work to the S3 API. 

### **Changes**
1. Add `WalkFiles` method to the storagedriver with slightly different behavior from `Walk`
    - `WalkFiles` does not walk over directories
    - `WalkFiles` does not have a special handling of `ErrSkipDir` to skip directory traversal without canceling the entire walk. Instead, any error will cancel the entire walk. 

1. Add an optimized implementation of `WalkFiles` for the s3 storagedriver, compared to `Walk`
   - Use `ListObjectsV2PagesWithContext` **without** a `Delimiter` gives up to 1000 files across directories
   - Avoids cases where an API call is made for a directory containing few files
   - When folders are ignored, this gives the same results but up to almost a thousand times fewer API calls

1. Utilize the `WalkFiles` method for blobstore enumeration

### **A different approach**

Change `storagedriver::Walk` interface to take options similar to `URLFor` 
- one option being whether or not to walk directories (default true)

### **Comparison**
For each registry ran `BlobEnumerator::enumerate` twice: Once using `StorageDriver::WalkFiles` and a second time using `StorageDriver::Walk`. Local changes were made to track the progress in the S3 `Walk` and `WalkFiles` implementations, giving the took, API calls, objects, and folders values below. 

**Test 1 (medium)**
- `WalkFiles` 
  - Took 0.128 seconds
  - 1 API call
  - 298 objects 
  - 0 folders
- `Walk` 
   - Took 53.9 seconds
   - 479 API calls
   - 298 objects 
   - 478 folders

**Results**
- Reduce runtime by factor of 421
- Reduce API calls by a factor of 479 

**Test 2 (large)**
Only the first 5 minutes of `Walk` are recorded and extrapolated, which I think is fair to get the point across
- `WalkFiles` 
  - Took 9.85 seconds
  - 49 API call
  - 48101 objects 
  - 0 folders
- `Walk` partial results
   - Took 5 minutes
   - 2680 API calls
   - 2663 objects (~1/18)
   - 2827 folders
- `Walk` extrapolated (x18)
   - Took 89.74 minutes
   - 48100 API calls
   - 47795 objects
   - 50739 folders

**Results**
- Reduce runtime by factor of 546
- Reduce API calls by a factor of 981. 
