### PR TITLE
storagedriver/s3: Handle bulk delete partial failures as failure

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1013,7 +1013,7 @@ ListLoop:
 		}
 		if output.Errors != nil && len(output.Errors) > 0 {
 			// ideally all errors would be returned in some way
-			// until then, at least pass back the first error message and code
+			// until then, at least pass back the first error code
 			oErr := output.Errors[0]
 			return errors.New(*oErr.Code)
 		}

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1015,7 +1015,7 @@ ListLoop:
 			// ideally all errors would be returned in some way
 			// until then, at least pass back the first error message and code
 			oErr := output.Errors[0]
-			return errors.New(fmt.Sprintf("%s (%s)", *oErr.Message, *oErr.Code))
+			return errors.New(*oErr.Code)
 		}
 	}
 	return nil

--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1000,7 +1001,7 @@ ListLoop:
 	// need to chunk objects into groups of 1000 per s3 restrictions
 	total := len(s3Objects)
 	for i := 0; i < total; i += 1000 {
-		_, err := s.DeleteObjects(&s3.DeleteObjectsInput{
+		output, err := s.DeleteObjects(&s3.DeleteObjectsInput{
 			Bucket: aws.String(d.Bucket),
 			Delete: &s3.Delete{
 				Objects: s3Objects[i:min(i+1000, total)],
@@ -1009,6 +1010,12 @@ ListLoop:
 		})
 		if err != nil {
 			return err
+		}
+		if output.Errors != nil && len(output.Errors) > 0 {
+			// ideally all errors would be returned in some way
+			// until then, at least pass back the first error message and code
+			oErr := output.Errors[0]
+			return errors.New(fmt.Sprintf("%s (%s)", *oErr.Message, *oErr.Code))
 		}
 	}
 	return nil


### PR DESCRIPTION
Updated the S3 Storage Driver `Delete` implementation to now return an error when one or more embedded response errors are returned. 

Part of the `DeleteObjectsOutput` response when using S3 SDK `DeleteObjects` is a list of zero or more errors pertaining to a particular key from the request.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html 
Example from the documentation
```
HTTP/1.1 200 OK
x-amz-id-2: 5h4FxSNCUS7wP5z92eGCWDshNpMnRuXvETa4HH3LvvH6VAIr0jU7tH9kM7X+njXx
x-amz-request-id: A437B3B641629AEE
Date: Fri, 02 Dec 2011 01:53:42 GMT
Content-Type: application/xml
Server: AmazonS3
Content-Length: 251

<?xml version="1.0" encoding="UTF-8"?>
<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 <Deleted>
   <Key>sample1.txt</Key>
 </Deleted>
 <Error>
  <Key>sample2.txt</Key>
  <Code>AccessDenied</Code>
  <Message>Access Denied</Message>
 </Error>
</DeleteResult>
```
Note the presence of `HTTP/1.1 200 OK` which I expect would result in no errors. With the proposed changes, a response like this will now result in an error `AccessDenied`
