### PR TITLE
DOCR-403 data plane HTTP 500 Responses (request cancellations) during DOKS cluster scale up

### DIFF
--- a/registry/api/errcode/register.go
+++ b/registry/api/errcode/register.go
@@ -55,6 +55,15 @@ var (
 		HTTPStatusCode: http.StatusForbidden,
 	})
 
+	// ErrorCodeClientDisconnected is returned if a client disconnects or cancels a request
+	// early
+	ErrorCodeClientDisconnected = Register("errcode", ErrorDescriptor{
+		Value:          "CLIENTDISCONNECTED",
+		Message:        "client disconnected",
+		Description:    `The client has disconnected or the HTTP request has been cancelled`,
+		HTTPStatusCode: 499,
+	})
+
 	// ErrorCodeUnavailable provides a common error to report unavailability
 	// of a service or endpoint.
 	ErrorCodeUnavailable = Register("errcode", ErrorDescriptor{

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -67,7 +67,8 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var handled bool
-	bh.Errors, handled = handleDisconnectionEvent(bh.Context, w, r)
+	errs, handled := handleDisconnectionEvent(bh.Context, w, r)
+	bh.Errors = append(errs)
 	if handled {
 		return
 	}

--- a/registry/handlers/blob.go
+++ b/registry/handlers/blob.go
@@ -3,12 +3,13 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	v2 "github.com/docker/distribution/registry/api/v2"
-	"github.com/gorilla/handlers"
-	"github.com/opencontainers/go-digest"
 )
 
 // blobDispatcher uses the request context to build a blobHandler.
@@ -65,7 +66,11 @@ func (bh *blobHandler) GetBlob(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-
+	var handled bool
+	bh.Errors, handled = handleDisconnectionEvent(bh.Context, w, r)
+	if handled {
+		return
+	}
 	if err := blobs.ServeBlob(bh, w, r, desc.Digest); err != nil {
 		context.GetLogger(bh).Debugf("unexpected error getting blob HTTP handler: %v", err)
 		bh.Errors = append(bh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -144,8 +144,8 @@ func (buh *blobUploadHandler) PatchBlobData(w http.ResponseWriter, r *http.Reque
 		switch err := err.(type) {
 		case storagedriver.QuotaExceededError:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied.WithMessage("quota exceeded"))
-		case storagedriver.ClientDisconnectedError:
-			buh.Errors = append(buh.Errors, errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected"))
+		case ErrorClientDisconnected:
+			buh.Errors = append(buh.Errors, err.CodeWithMessage())
 		default:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
 		}
@@ -199,8 +199,8 @@ func (buh *blobUploadHandler) BlobUploadComplete(w http.ResponseWriter, r *http.
 		switch err := err.(type) {
 		case storagedriver.QuotaExceededError:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied.WithMessage("quota exceeded"))
-		case storagedriver.ClientDisconnectedError:
-			buh.Errors = append(buh.Errors, errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected"))
+		case ErrorClientDisconnected:
+			buh.Errors = append(buh.Errors, err.CodeWithMessage())
 		default:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
 		}

--- a/registry/handlers/blobupload.go
+++ b/registry/handlers/blobupload.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gorilla/handlers"
+	"github.com/opencontainers/go-digest"
+
 	"github.com/docker/distribution"
 	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/reference"
@@ -12,8 +15,6 @@ import (
 	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/storage"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
-	"github.com/gorilla/handlers"
-	"github.com/opencontainers/go-digest"
 )
 
 // blobUploadDispatcher constructs and returns the blob upload handler for the
@@ -143,6 +144,8 @@ func (buh *blobUploadHandler) PatchBlobData(w http.ResponseWriter, r *http.Reque
 		switch err := err.(type) {
 		case storagedriver.QuotaExceededError:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied.WithMessage("quota exceeded"))
+		case storagedriver.ClientDisconnectedError:
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected"))
 		default:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
 		}
@@ -196,6 +199,8 @@ func (buh *blobUploadHandler) BlobUploadComplete(w http.ResponseWriter, r *http.
 		switch err := err.(type) {
 		case storagedriver.QuotaExceededError:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeDenied.WithMessage("quota exceeded"))
+		case storagedriver.ClientDisconnectedError:
+			buh.Errors = append(buh.Errors, errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected"))
 		default:
 			buh.Errors = append(buh.Errors, errcode.ErrorCodeUnknown.WithDetail(err.Error()))
 		}

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -2,13 +2,22 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 
 	dcontext "github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 )
+
+type ErrorClientDisconnected struct{}
+
+func (e ErrorClientDisconnected) Error() string {
+	return errcode.ErrorCodeClientDisconnected.Error()
+}
+
+func (e ErrorClientDisconnected) CodeWithMessage() errcode.Error {
+	return errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected")
+}
 
 // closeResources closes all the provided resources after running the target
 // handler.
@@ -53,7 +62,7 @@ func copyFullPayload(ctx context.Context, responseWriter http.ResponseWriter, r 
 				"copied":        copied,
 				"contentLength": r.ContentLength,
 			}, "error", "copied", "contentLength").Error("client disconnected during " + action)
-			return errors.New("client disconnected")
+			return ErrorClientDisconnected{}
 		default:
 		}
 	}
@@ -76,7 +85,7 @@ func checkForClientDisconnection(w http.ResponseWriter, r *http.Request) error {
 		select {
 		case <-clientClosed:
 			w.WriteHeader(499)
-			return errors.New("client disconnected")
+			return ErrorClientDisconnected{}
 		default:
 		}
 	}
@@ -89,8 +98,9 @@ func checkForClientDisconnection(w http.ResponseWriter, r *http.Request) error {
 func handleDisconnectionEvent(ctx *Context, w http.ResponseWriter, r *http.Request) ([]error, bool) {
 	handled := false
 	disconnected := checkForClientDisconnection(w, r)
+	err := disconnected.(ErrorClientDisconnected)
 	if disconnected != nil {
-		ctx.Errors = append(ctx.Errors, errcode.ErrorCodeClientDisconnected.WithMessage("client disconnected"))
+		ctx.Errors = append(ctx.Errors, err.CodeWithMessage())
 		handled = true
 	}
 	return ctx.Errors, handled

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -2,11 +2,12 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 
 	dcontext "github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/api/errcode"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 )
 
 // closeResources closes all the provided resources after running the target
@@ -52,7 +53,7 @@ func copyFullPayload(ctx context.Context, responseWriter http.ResponseWriter, r 
 				"copied":        copied,
 				"contentLength": r.ContentLength,
 			}, "error", "copied", "contentLength").Error("client disconnected during " + action)
-			return errors.New("client disconnected")
+			return storagedriver.ClientDisconnectedError{}
 		default:
 		}
 	}
@@ -63,4 +64,35 @@ func copyFullPayload(ctx context.Context, responseWriter http.ResponseWriter, r 
 	}
 
 	return nil
+}
+
+// checkForClientDisconnection is a generic function which checks if a HTTP request for a given client has been closed
+// and if it has returns a typed client disconnection event
+func checkForClientDisconnection(w http.ResponseWriter, r *http.Request) *storagedriver.ClientDisconnectedError {
+	var body = r.Body
+	clientClosed := r.Context().Done()
+	bodyLen, err := body.Read([]byte{})
+	if clientClosed != nil && (err != nil || (r.ContentLength > 0 && int64(bodyLen) < r.ContentLength)) {
+		select {
+		case <-clientClosed:
+			w.WriteHeader(499)
+			return &storagedriver.ClientDisconnectedError{}
+		default:
+		}
+	}
+	return nil
+}
+
+// handleDisconnectionEvent is a utility abstraction for checking client disconnection events and ensures the correct
+// 499 error is surfaced to the client. As this logic is used in multiple places this prevents the handling logic
+// from being duplicated
+func handleDisconnectionEvent(ctx *Context, w http.ResponseWriter, r *http.Request) ([]error, bool) {
+	handled := false
+	disconnected := checkForClientDisconnection(w, r)
+	if disconnected != nil {
+		ctx.Errors = append(ctx.Errors, errcode.ErrorCodeClientDisconnected.WithDetail(disconnected))
+		handled = true
+	}
+	return ctx.Errors, handled
+
 }

--- a/registry/handlers/helpers.go
+++ b/registry/handlers/helpers.go
@@ -98,8 +98,8 @@ func checkForClientDisconnection(w http.ResponseWriter, r *http.Request) error {
 func handleDisconnectionEvent(ctx *Context, w http.ResponseWriter, r *http.Request) ([]error, bool) {
 	handled := false
 	disconnected := checkForClientDisconnection(w, r)
-	err := disconnected.(ErrorClientDisconnected)
 	if disconnected != nil {
+		err := disconnected.(ErrorClientDisconnected)
 		ctx.Errors = append(ctx.Errors, err.CodeWithMessage())
 		handled = true
 	}

--- a/registry/handlers/helpers_test.go
+++ b/registry/handlers/helpers_test.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/docker/distribution/registry/api/errcode"
+)
+
+func createCancelledRequest(shouldCancel bool) (*http.Request, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	testRequest, err := http.NewRequest("GET", "/", strings.NewReader(""))
+	if err != nil {
+		return nil, err
+	}
+	cancelledRequest := testRequest.WithContext(ctx)
+	if shouldCancel {
+		cancel()
+	}
+	return cancelledRequest, nil
+}
+
+func TestCheckForClientDisconnection(t *testing.T) {
+	r, err := createCancelledRequest(true)
+	w := httptest.NewRecorder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	disconnected := checkForClientDisconnection(w, r)
+	if disconnected == nil {
+		t.Fatal("expected client disconnected error got nil")
+	}
+	if !strings.Contains(disconnected.Error(), "client disconnected") {
+		t.Fatalf("expected error to signify client disconnection got %s", disconnected.Error())
+	}
+	if w.Result().StatusCode != 499 {
+		t.Fatalf("expected status code 499 got %d", w.Result().StatusCode)
+	}
+}
+
+func TestClientNotDisconnected(t *testing.T) {
+	r, err := createCancelledRequest(false)
+	w := httptest.NewRecorder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	disconnected := checkForClientDisconnection(w, r)
+	if disconnected != nil {
+		t.Fatal("expected no error got client disconnected")
+	}
+	if w.Result().StatusCode == 499 {
+		t.Fatal("unexpected status code 499")
+	}
+}
+
+func TestHandleDisconnectionEvent(t *testing.T) {
+	ctx := Context{
+		Errors: errcode.Errors{},
+	}
+	r, err := createCancelledRequest(true)
+	w := httptest.NewRecorder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result bool
+	ctx.Errors, result = handleDisconnectionEvent(&ctx, w, r)
+	if !result {
+		t.Fatal("disconnection event not handled correctly")
+	}
+	found := false
+	for _, err := range ctx.Errors {
+		if err.Error() == "clientdisconnected: client disconnected" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("request context does not contain a disconnection event")
+	}
+}
+
+func TestHandleNonDisconnectionEvent(t *testing.T) {
+	ctx := Context{
+		Errors: errcode.Errors{},
+	}
+	r, err := createCancelledRequest(false)
+	w := httptest.NewRecorder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result bool
+	ctx.Errors, result = handleDisconnectionEvent(&ctx, w, r)
+	if result {
+		t.Fatal("disconnection event not handled correctly")
+	}
+	if ctx.Errors.Len() > 0 {
+		t.Fatalf("unexpected context errors received %v", ctx.Errors)
+	}
+}

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -129,7 +129,8 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 				imh.Errors = append(imh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
 			} else {
 				var handled bool
-				imh.Errors, handled = handleDisconnectionEvent(imh.Context, w, r)
+				errs, handled := handleDisconnectionEvent(imh.Context, w, r)
+				imh.Errors = append(errs)
 				if handled {
 					return
 				}
@@ -155,7 +156,8 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 			imh.Errors = append(imh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
 		} else {
 			var handled bool
-			imh.Errors, handled = handleDisconnectionEvent(imh.Context, w, r)
+			errs, handled := handleDisconnectionEvent(imh.Context, w, r)
+			imh.Errors = append(errs)
 			if handled {
 				return
 			}
@@ -223,7 +225,8 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 				imh.Errors = append(imh.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
 			} else {
 				var handled bool
-				imh.Errors, handled = handleDisconnectionEvent(imh.Context, w, r)
+				errs, handled := handleDisconnectionEvent(imh.Context, w, r)
+				imh.Errors = append(errs)
 				if handled {
 					return
 				}

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/handlers"
+
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/api/errcode"
 	v2 "github.com/docker/distribution/registry/api/v2"
-	"github.com/gorilla/handlers"
 )
 
 // tagsDispatcher constructs the tags handler api endpoint.
@@ -44,6 +45,11 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 		case errcode.Error:
 			th.Errors = append(th.Errors, err)
 		default:
+			var handled bool
+			th.Errors, handled = handleDisconnectionEvent(th.Context, w, r)
+			if handled {
+				return
+			}
 			th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}
 		return

--- a/registry/handlers/tags.go
+++ b/registry/handlers/tags.go
@@ -46,7 +46,8 @@ func (th *tagsHandler) GetTags(w http.ResponseWriter, r *http.Request) {
 			th.Errors = append(th.Errors, err)
 		default:
 			var handled bool
-			th.Errors, handled = handleDisconnectionEvent(th.Context, w, r)
+			errs, handled := handleDisconnectionEvent(th.Context, w, r)
+			th.Errors = append(errs)
 			if handled {
 				return
 			}

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -169,6 +169,16 @@ func (err QuotaExceededError) Error() string {
 	return fmt.Sprintf("%s: quota exceeded", err.DriverName)
 }
 
+// ClientDisconnectedError is returned when a client disconnects or a request context is cancelled during
+// a write
+type ClientDisconnectedError struct {
+	DriverName string
+}
+
+func (err ClientDisconnectedError) Error() string {
+	return fmt.Sprintf("%s: client disconnected", err.DriverName)
+}
+
 // Error is a catch-all error type which captures an error string and
 // the driver type on which it occurred.
 type Error struct {

--- a/registry/storage/driver/storagedriver.go
+++ b/registry/storage/driver/storagedriver.go
@@ -169,16 +169,6 @@ func (err QuotaExceededError) Error() string {
 	return fmt.Sprintf("%s: quota exceeded", err.DriverName)
 }
 
-// ClientDisconnectedError is returned when a client disconnects or a request context is cancelled during
-// a write
-type ClientDisconnectedError struct {
-	DriverName string
-}
-
-func (err ClientDisconnectedError) Error() string {
-	return fmt.Sprintf("%s: client disconnected", err.DriverName)
-}
-
 // Error is a catch-all error type which captures an error string and
 // the driver type on which it occurred.
 type Error struct {


### PR DESCRIPTION
Fixes an issue where docker clients are erroneously presented with a 500 error steming from client disconnection events. My test case was as follows:

* Pull a docker image from Dockerhub and retag for use with local development environment
* While monitoring distribution logs start a`docker push`
* Cancel the `docker push` and this simulated a cancellation

In the logs before this change we can see a response of 500

```
"err.code":"unknown","err.detail":"client disconnected","err.message":"unknown error",

"http.response.contenttype":"application/json","http.response.duration":"312.037929ms","http.response.status":500,"http.response.written":89,"instance.id":"9cd4602b-3d31-4cc1-a8c6-8f9eab8d79af","level":"error","msg":"response completed with 
```

This was wrong as according to distribution code here https://github.com/digitalocean/docker-distribution/blob/97f8646bfd627b2ee5405fb13c6554d93525bc1b/registry/handlers/helpers.go#L43-L55 logs should have shown a 499 status code. Now with the following change I can see

```
"http.response.status":499,"http.response.written":75,"instance.id":"02dc0afb-23b1-4020-b3c9-7df015cae2d7","level":"error","msg":"response completed with error"
```

**Note this currently covers PUT and PATCH and we need to make sure this logic is applied to other areas as well** - Annoyingly this is difficult because of the handler structure. By the time we can interact with the errors its already too late