### PR TITLE
Set HTTP Server Timeouts

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -164,6 +164,9 @@ func NewRegistry(ctx context.Context, config *configuration.Configuration) (*Reg
 	server := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       60 * time.Minute,
+		WriteTimeout:      60 * time.Minute,
+		IdleTimeout:       60 * time.Minute,
 	}
 
 	return &Registry{

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -166,7 +166,7 @@ func NewRegistry(ctx context.Context, config *configuration.Configuration) (*Reg
 		ReadHeaderTimeout: readHeaderTimeout,
 		ReadTimeout:       60 * time.Minute,
 		WriteTimeout:      60 * time.Minute,
-		IdleTimeout:       60 * time.Minute,
+		IdleTimeout:       5 * time.Minute,
 	}
 
 	return &Registry{


### PR DESCRIPTION
This PR add HTTP Server Timeouts to prevent R.U.D.Y. attacks.

Jira:
* [DOCR-1663](https://do-internal.atlassian.net/browse/DOCR-1663)

[DOCR-1663]: https://do-internal.atlassian.net/browse/DOCR-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ