### PR TITLE
Log Content-Length

### DIFF
--- a/context/http.go
+++ b/context/http.go
@@ -219,6 +219,10 @@ func (ctx *httpRequestContext) Value(key interface{}) interface{} {
 			if ct := ctx.r.Header.Get("Content-Type"); ct != "" {
 				return ct
 			}
+		case "http.request.content-length":
+			if cl := ctx.r.Header.Get("Content-Length"); cl != "" {
+				return cl
+			}
 		case "cf-ray":
 			ct := ctx.r.Header.Get("CF-RAY")
 			if ct != "" {


### PR DESCRIPTION
This PR adds the content-length of the HTTP request in the logs. The `GetRequestLogger` already has support for the content-length key -> https://github.com/digitalocean/docker-distribution/blob/b53b39de00e0b32a927c085297222be191069aff/context/http.go#L146-L158

Its just that it has to be returned by `httpRequestContext`'s Value function https://github.com/digitalocean/docker-distribution/blob/b53b39de00e0b32a927c085297222be191069aff/context/http.go#L194