### PR TITLE
fix: add parseError to multipart copy and zero-length upload paths

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -1019,7 +1019,7 @@ func (d *driver) copy(ctx context.Context, sourcePath string, destPath string) e
 		StorageClass:         d.getStorageClass(),
 	})
 	if err != nil {
-		return err
+		return parseError(destPath, err)
 	}
 
 	numParts := (fileInfo.Size() + d.MultipartCopyChunkSize - 1) / d.MultipartCopyChunkSize
@@ -1058,7 +1058,7 @@ func (d *driver) copy(ctx context.Context, sourcePath string, destPath string) e
 	for range completedParts {
 		err := <-errChan
 		if err != nil {
-			return err
+			return parseError(sourcePath, err)
 		}
 	}
 
@@ -1068,7 +1068,7 @@ func (d *driver) copy(ctx context.Context, sourcePath string, destPath string) e
 		UploadId:        createResp.UploadId,
 		MultipartUpload: &s3.CompletedMultipartUpload{Parts: completedParts},
 	})
-	return err
+	return parseError(destPath, err)
 }
 
 // Delete recursively deletes all objects stored at "path" and its subpaths.
@@ -1679,7 +1679,7 @@ func (w *writer) Commit() error {
 			Body:       bytes.NewReader(nil),
 		})
 		if err != nil {
-			return err
+			return parseError(w.key, err)
 		}
 
 		completedUploadedParts = append(completedUploadedParts, &s3.CompletedPart{


### PR DESCRIPTION
Addresses: https://do-internal.atlassian.net/browse/DOCR-2096

The multipart copy path in the S3 driver's copy() function returned raw AWS SDK errors without passing them through parseError(). This meant QuotaExceeded errors were not converted to storagedriver.QuotaExceededError, causing the handler-level type switches to miss them and fall through to the default case, resulting in HTTP 500 instead of HTTP 403.

Add parseError() calls to:
- CreateMultipartUpload error return
- UploadPartCopy errChan error return
- CompleteMultipartUpload error return
- Zero-length UploadPart edge case in writer Commit()