### PR TITLE
fix: return manifest unknown when content exceeds the read limit

### DIFF
--- a/registry/storage/io.go
+++ b/registry/storage/io.go
@@ -12,6 +12,11 @@ const (
 	maxBlobGetSize = 4 << 20
 )
 
+// errReadExceedsLimit is returned when a read exceeds the limit set by
+// limitReader. It is a sentinel so callers can distinguish oversized content
+// from other storage errors.
+var errReadExceedsLimit = errors.New("storage: read exceeds limit")
+
 func getContent(ctx context.Context, driver driver.StorageDriver, p string) ([]byte, error) {
 	r, err := driver.Reader(ctx, p, 0)
 	if err != nil {
@@ -66,6 +71,6 @@ func (l *limitedReader) Read(p []byte) (n int, err error) {
 	n = int(l.n)
 	l.n = 0
 
-	l.err = errors.New("storage: read exceeds limit")
+	l.err = errReadExceedsLimit
 	return n, l.err
 }

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/docker/distribution"
@@ -80,7 +81,11 @@ func (ms *manifestStore) Get(ctx context.Context, dgst digest.Digest, options ..
 
 	content, err := ms.blobStore.Get(ctx, dgst)
 	if err != nil {
-		if err == distribution.ErrBlobUnknown {
+		// A valid manifest can never exceed the read limit because manifest
+		// PUTs are capped at the same size, so an oversized read here means
+		// the digest refers to a blob (e.g. a layer), not a manifest. Treat
+		// it as an unknown manifest (404) rather than an internal error.
+		if err == distribution.ErrBlobUnknown || errors.Is(err, errReadExceedsLimit) {
 			return nil, distribution.ErrManifestUnknownRevision{
 				Name:     ms.repository.Named().Name(),
 				Revision: dgst,

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -585,6 +585,40 @@ func TestManifestGetNonManifestContent(t *testing.T) {
 	}
 }
 
+// TestManifestGetOversizedBlobContent ensures that fetching a digest whose
+// content exceeds the blob read limit through the manifest service reports
+// ErrManifestUnknownRevision (mapped to 404 by the API) rather than the
+// untyped read-limit error (mapped to 500). Oversized content can never be a
+// valid manifest because manifest puts are capped at the same size.
+func TestManifestGetOversizedBlobContent(t *testing.T) {
+	repoName, _ := reference.WithName("foo/bar")
+	env := newManifestStoreTestEnv(t, repoName, "thetag")
+
+	ctx := context.Background()
+	manifestService, err := env.repository.Manifests(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A blob just over the read limit, e.g. a layer or large config blob
+	// requested through the manifests endpoint.
+	content := make([]byte, maxBlobGetSize+1)
+
+	descriptor, err := env.repository.Blobs(ctx).Put(ctx, "", content)
+	if err != nil {
+		t.Fatalf("unexpected error putting content as a blob: %v", err)
+	}
+
+	_, err = manifestService.Get(ctx, descriptor.Digest)
+	if err == nil {
+		t.Fatal("expected an error fetching oversized content as a manifest")
+	}
+
+	if _, ok := err.(distribution.ErrManifestUnknownRevision); !ok {
+		t.Fatalf("expected ErrManifestUnknownRevision, got %T: %v", err, err)
+	}
+}
+
 // TestManifestGetMalformedIndexWithoutMediaType covers content that reaches the
 // empty-media-type branch and fails image index unmarshalling. The index
 // handler returns a nil manifest alongside its error, so Get must check that


### PR DESCRIPTION
## Summary
- Fetching a **blob digest** (layer/config) through the manifest service reads the raw blob content; for blobs over 4 MiB (`maxBlobGetSize`) this fails with the untyped error `storage: read exceeds limit`, which the registry API maps to **HTTP 500** — burning DOCR's error-rate SLO when a client hits the wrong endpoint.
- Manifest PUTs are capped at the same 4 MiB (`maxManifestBodySize` in the handlers), so oversized content reached through the manifest endpoint can never be a valid manifest. This maps the read-limit error to `distribution.ErrManifestUnknownRevision`, which the API layer already translates to **404 `MANIFEST_UNKNOWN`**.

## Changes
- `registry/storage/io.go`: promote the inline `storage: read exceeds limit` error to a package sentinel `errReadExceedsLimit` (same message, now matchable).
- `registry/storage/manifeststore.go`: in `manifestStore.Get`, map `errReadExceedsLimit` to `ErrManifestUnknownRevision` alongside the existing `ErrBlobUnknown` case. No happy-path changes.
- `registry/storage/manifeststore_test.go`: add `TestManifestGetOversizedBlobContent` following the DOCR-2302 (#60) test pattern.

## Context
Production incident (docr-alerts, Aug 19–20): a customer tool fetched blob digests via `GET /v2/<repo>/manifests/<digest>` for blobs >4 MiB, producing a sustained stream of 500s and retries for ~10.5h. The same digests succeed via the blobs endpoint. This is the >4 MiB counterpart of the sub-4 MiB non-manifest-content cases fixed in #60 (DOCR-2302).

Once merged, `docr` will pick this up via a `go.mod` pseudo-version bump + `go mod vendor` (replacing https://github.internal.digitalocean.com/digitalocean/docr/pull/310, which had edited vendor files directly).

## Testing
- `go test ./registry/storage/ -run TestManifestGet -v` — all pass, including the new test.
- The four failures in the full package run (`TestSimpleBlobUpload`, `TestBlobMount`, `TestLinkedBlobStoreCreateWithMountFrom`, `TestManifestStorage`) are pre-existing on master (verified via stash) and unrelated.